### PR TITLE
Upgrade to latest mongoose and node

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');
 var ShortId = require('./shortid');
 
 var defaultSave = mongoose.Model.prototype.save;
-mongoose.Model.prototype.save = function(cb) {
+mongoose.Model.prototype.save = function(options, cb) {
     var self = this;
     for (fieldName in this.schema.tree) {
         if (self.isNew && self[fieldName] === undefined) {
@@ -19,7 +19,7 @@ mongoose.Model.prototype.save = function(cb) {
                             return;
                         }
                         self[fieldName] = id;
-                        defaultSave.call(self, function(err, obj) {
+                        defaultSave.call(self, options, function(err, obj) {
                             if (err &&
                                 err.code == 11000 &&
                                 err.err.indexOf(fieldName) !== -1 &&
@@ -39,7 +39,7 @@ mongoose.Model.prototype.save = function(cb) {
             }
         }
     }
-    defaultSave.call(this, cb);
+    defaultSave.call(this, options, cb);
 };
 
 module.exports = exports = ShortId;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mongoose"
   ],
   "dependencies": {
-    "bignum": "0.9.2"
+    "bignum": "0.11.0"
   },
   "devDependencies": {
     "grunt-cli": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-shell": "0.7.0",
     "grunt-bump": "0.0.16",
     "mocha": "2.0.1",
-    "mongoose": "^4.4.2",
+    "mongoose": "^4.4.12",
      "async": "^0.9.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-shell": "0.7.0",
     "grunt-bump": "0.0.16",
     "mocha": "2.0.1",
-    "mongoose": "^4.1.9",
+    "mongoose": "^4.4.2",
      "async": "^0.9.0"
   },
   "scripts": {


### PR DESCRIPTION
Dusting this off -- unit tests pass with latest LTS node as of this writing -- 4.4.3. The main change here to note is that the signature for Model.save changed a while back in Mongoose which broke our monkey patching. 
